### PR TITLE
simple memory 'library'

### DIFF
--- a/ImClass.vcxproj
+++ b/ImClass.vcxproj
@@ -166,6 +166,7 @@
     <ClInclude Include="include\imgui\imstb_rectpack.h" />
     <ClInclude Include="include\imgui\imstb_textedit.h" />
     <ClInclude Include="include\imgui\imstb_truetype.h" />
+    <ClInclude Include="memory.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ImClass.vcxproj.filters
+++ b/ImClass.vcxproj.filters
@@ -68,5 +68,8 @@
     <ClInclude Include="include\imgui\imstb_truetype.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="memory.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/main.cpp
+++ b/main.cpp
@@ -1,7 +1,9 @@
 #include <Windows.h>
 #include <iostream>
+#include <string>
 
 #include <directx.h>
+#include <memory.h>
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow) {
     WNDCLASS wc = { CS_CLASSDC, WndProc, 0, 0, hInstance, nullptr, nullptr, nullptr, nullptr, L"ImClassWnd" };

--- a/memory.h
+++ b/memory.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <Windows.h>
+#include <vector>
+#include <tlhelp32.h>
+
+struct processSnapshot {
+    std::wstring name;
+    DWORD pid;
+};
+
+struct moduleInfo {
+    uintptr_t base;
+    DWORD size;
+};
+
+namespace mem {
+    std::vector<processSnapshot> processes;
+    HANDLE memHandle;
+    DWORD pid;
+
+    bool getProcessList();
+    HANDLE openHandle(DWORD pid);
+    bool getModuleInfo(DWORD pid, const wchar_t* moduleName, moduleInfo* info);
+    bool read(uintptr_t address, void* buf, uintptr_t size);
+    bool write(uintptr_t address, const void* buf, uintptr_t size);
+    bool initProcess(const wchar_t* processName);
+    bool initProcess(DWORD pid);
+}
+
+bool mem::getProcessList() {
+    processes.clear();
+
+    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnapshot == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    PROCESSENTRY32 processEntry;
+    processEntry.dwSize = sizeof(PROCESSENTRY32);
+
+    if (Process32First(hSnapshot, &processEntry)) {
+        do {
+            processSnapshot snapshot{ processEntry.szExeFile, processEntry.th32ProcessID };
+            processes.push_back(snapshot);
+        } while (Process32Next(hSnapshot, &processEntry));
+    }
+
+    CloseHandle(hSnapshot);
+    return true;
+}
+
+bool mem::getModuleInfo(DWORD pid, const wchar_t* moduleName, moduleInfo* info) {
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid);
+    if (snapshot == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    MODULEENTRY32W entry = {};
+    entry.dwSize = sizeof(MODULEENTRY32W);
+
+    if (Module32FirstW(snapshot, &entry)) {
+        do {
+            if (wcsstr(moduleName, entry.szModule)) {
+                info->base = (uintptr_t)entry.modBaseAddr;
+                info->size = entry.modBaseSize;
+                return true;
+            }
+        } while (Module32NextW(snapshot, &entry));
+    }
+
+    CloseHandle(snapshot);
+
+    return true;
+}
+
+HANDLE mem::openHandle(DWORD pid) {
+    memHandle = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_VM_WRITE, FALSE, pid);
+    return memHandle;
+}
+
+bool mem::read(uintptr_t address, void* buf, uintptr_t size) {
+    size_t sizeRead;
+    return ReadProcessMemory(memHandle, (void*)address, buf, size, &sizeRead);
+}
+
+bool mem::write(uintptr_t address, const void* buf, uintptr_t size) {
+    size_t sizeWritten;
+    return WriteProcessMemory(memHandle, (void*)address, buf, size, &sizeWritten);
+}
+
+bool mem::initProcess(const wchar_t* processName) {
+    if (!getProcessList()) {
+        return false;
+    }
+
+    for (auto& proc : processes) {
+        if (!wcscmp(proc.name.c_str(), processName)) {
+            if (openHandle(proc.pid)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool mem::initProcess(DWORD pid) {
+    mem::pid = pid;
+    return openHandle(pid);
+}
+
+template <typename T>
+T Read(uintptr_t address) {
+    T response{};
+    mem::read(address, &response, sizeof(T));
+
+    return response;
+}
+
+template <typename T>
+bool Write(uintptr_t address, const T& value) {
+    return mem::write(address, &value, sizeof(T));
+}


### PR DESCRIPTION
Memory namespace
-
- Reads process list
- Can open a memory handle
- Can get module info
- Can read and write memory


Simple test that it works (Reading an exe MZ header):
```cpp
if (mem::initProcess(L"ImClass.exe")) {
    moduleInfo mod;
    if (mem::getModuleInfo(mem::pid, L"ImClass.exe", &mod)) {
        uint16_t first2bytes = Read<uint16_t>(mod.base);
        char test[3];
        *(uint16_t*)(test) = first2bytes;
        test[2] = 0;
        MessageBoxA(0, test, "aa", 0);
    }
}
```
Output: 
![image](https://github.com/user-attachments/assets/9c0e5e7f-52e1-4841-b6ac-83ad259f43d9)
