### PR TITLE
Fix sigscan menu ui

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -174,7 +174,7 @@ void ui::renderMain() {
             ImGui::EndMenu();
         }
         if (ImGui::BeginMenu("Tools")) {
-            if (ImGui::Button("Signature Scanner"))
+            if (ImGui::MenuItem("Signature Scanner"))
             {
                 sigScanWindow = true;
             }


### PR DESCRIPTION
Use ImGui::MenuItem for sigscan in the menu bar rather than ImGui::Button

![image](https://github.com/user-attachments/assets/99a9c7b9-15c5-4e3b-ae4d-559cd431902c)


![image](https://github.com/user-attachments/assets/82aee6c2-04d5-4f8e-8980-6dbb2d6fbf0c)
